### PR TITLE
Typo #L5 lj-maintenance-mode.php

### DIFF
--- a/lj-maintenance-mode.php
+++ b/lj-maintenance-mode.php
@@ -2,7 +2,7 @@
 /**
 * Plugin Name: Maintenance Mode
 * Plugin URI: https://github.com/lukasjuhas/lj-maintenance-mode
-* Description: Very simple Maintenance Mode & Coming soon page. Using default Wordpress markup, No adds, no paid upgrades.
+* Description: Very simple Maintenance Mode & Coming soon page. Using default Wordpress markup, No ads, no paid upgrades.
 * Version: 1.3
 * Author: Lukas Juhas
 * Author URI: http://lukasjuhas.com


### PR DESCRIPTION
Hi, 
I translated the plugin on translate.wordpress.org and found this typo.
Changed "no adds" to "no ads"
