### PR TITLE
Add 503 status code to maintenance mode.

### DIFF
--- a/lj-maintenance-mode.php
+++ b/lj-maintenance-mode.php
@@ -227,7 +227,7 @@ class ljMaintenanceMode {
             }
             $content = apply_filters('the_content', $content);
 
-            wp_die($content, get_bloginfo( 'name' ) . ' - ' . __('Website Under Maintenance', LJMM_PLUGIN_DOMAIN));
+            wp_die($content, get_bloginfo( 'name' ) . ' - ' . __('Website Under Maintenance', LJMM_PLUGIN_DOMAIN), array('response' => '503'));
         }
     }
 


### PR DESCRIPTION
Currently lj-maintenance-mode sends a '500 Server Error' as a status code. This change sends a '503 Service Unavailable' instead which would be more desirable as it should not affect search engine indexing. The 503 would tell the search engine spiders that the server is temporarily unavailable and they should come back later.

Love the plugin by the way.

Thanks,
Jason Komar
