### PR TITLE
Issue #20 suggested solution (SiteOrigin Page Builder conflict)

### DIFF
--- a/lj-maintenance-mode.php
+++ b/lj-maintenance-mode.php
@@ -454,7 +454,12 @@ class ljMaintenanceMode
     {
         $get_content = get_option('ljmm-content');
         $content = (!empty($get_content)) ? $get_content : ljmm_get_defaults('maintenance_message');
-        $content = apply_filters('the_content', $content);
+        $content = apply_filters('wptexturize', $content);
+        $content = apply_filters('wpautop', $content);
+        $content = apply_filters('shortcode_unautop', $content);
+        $content = apply_filters('prepend_attachment', $content);
+        $content = apply_filters('wp_make_content_images_responsive', $content);
+        $content = apply_filters('convert_smilies', $content);
         $content = apply_filters('ljmm_content', $content);
 
         return $content;


### PR DESCRIPTION
As plugins can hook onto 'the-content' filter, the application of the filter was replaced with calls to specific filters of interest. The idea was borrowed from https://wordpress.stackexchange.com/questions/134582/apply-filtersthe-content-content-alternative