### PR TITLE
Added support for widgets, custom stylesheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ $RECYCLE.BIN/
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -41,3 +42,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# IDE config files
+.idea

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,13 +1,13 @@
 # Changelog
 
 ## 2.4
-* Added support for stylesheet and widgets (Thanks to Eric Mueller at [@switchplus](https://github.com/switchplus))
+* Added support for stylesheet, widgets and code snippet injection (Thanks to Eric Mueller at [@switchplus](https://github.com/switchplus))
 
 ## 2.3.2
-* Added SiteOrigin Page Builder compatibilty (Thanks to [@relgit](https://github.com/relgit))
+* Added SiteOrigin Page Builder compatibility (Thanks to [@relgit](https://github.com/relgit))
 
 ## 2.3.1
-* Hot Fix issue where user got locked out of admin area in maitenanice mode.
+* Hot Fix issue where user got locked out of admin area in maintenance mode.
 
 ## 2.3
 * Small refactor, extract some of the parts to it's own method to make everything a bit cleaner

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.4
-* Added support for stylesheet, widgets and code snippet injection (Thanks to Eric Mueller at [@switchplus](https://github.com/switchplus))
+* Added support for stylesheet, widgets, code snippet injection and Analytify/Google Analytics tracking code (Thanks to Eric Mueller at [@switchplus](https://github.com/switchplus))
 
 ## 2.3.2
 * Added SiteOrigin Page Builder compatibility (Thanks to [@relgit](https://github.com/relgit))

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4
+* Added support for stylesheet and widgets (Thanks to Eric Mueller at [@switchplus](https://github.com/switchplus))
+
 ## 2.3.2
 * Added SiteOrigin Page Builder compatibilty (Thanks to [@relgit](https://github.com/relgit))
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Help support and translate this plugin!
 * **WPML Compatible** - Plugin is compatible with WPML plugin
 * **Optional widgets** - Optionally add widgets above and/or below the content
 * **Optional style sheet** - Optionally add a custom style sheet
-* **Optional ability to add code snippet** - Optionally add a code snippet to the page-- for example, Google Analytics tracking code.
+* **Optional ability to add code snippet** - Optionally add a code snippet to the page.
+* **Support for Analytify plugin** - If you use the Analytify plugin, you can automatically insert the Google Analytics tracking code.
 
 Bugs and pull requests are welcomed.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Maintenance Mode (2.3.2)
-========================
+Maintenance Mode (2.4)
+======================
 
 * Contributors: Lukas Juhas
 * Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=2XPA4CKT836FJ
@@ -25,6 +25,8 @@ Help support and translate this plugin!
 * **Compact** - It's developed to be as compact as possible.
 * **Role Control** - User Role control is available since 2.0
 * **WPML Compatible** - Plugin is compatible with WPML plugin
+* **Optional widgets** - Optionally add widgets above and/or below the content
+* **Optional style sheet** - Optionally add a custom style sheet
 
 Bugs and pull requests are welcomed.
 
@@ -33,6 +35,9 @@ Bugs and pull requests are welcomed.
 `ljmm_site_title` - Filter page title while in maintenance mode
 
 `ljmm_admin_bar_indicator_enabled` - Control visibility of admin bar indicator
+
+`limm_css_filename` - The filename of the CSS style sheet (as found in the theme's stylesheet directory) - just the filename, for example: `maintenance.css.min`. (Note: you do not need to use this filter for a stylesheet; see FAQs below.)
+
 
 ## Actions ##
 `ljmm_before_mm` - Runs at the beginning of core maintenance method
@@ -52,10 +57,16 @@ Bugs and pull requests are welcomed.
 1. Is this plugin really ad free ?<br>
 Yes.
 
-2. Can I change colours?<br>
-Not by default. Unless you are developer and you "inject" your own styles in to the wp_die() page.
+2. Can I change background colour?<br>
+Not through the admin interface. You can use a custom stylesheet (see next FAQ) to do this, however.
 
-3. Plugin doesn't seem to work. What should I do ?<br>
+3. What is the default stylesheet?<br>
+By default, the plugin will use a stylesheet named `maintenance.css.min` in the theme's stylesheet folder. You can specify a different filename by using a Filter (above).
+
+4. How do I add widgets?<br>
+Click "Advanced Settings" and mark the checkbox to add widget areas. Then you will find two new widget areas in WordPress's Widgets page, for above and below the content.
+
+5. Plugin doesn't seem to work. What should I do ?<br>
 First, if you are using Cache plugin such as WP Super Cache or W3 Total Cache, flush all your cache. Secondly, disable all other plugins and try enabling just Maintenance Mode and see if problem persist. This should solve most common problems. If not, don't hesitate to contact me via Support button from Settings page
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Help support and translate this plugin!
 * **WPML Compatible** - Plugin is compatible with WPML plugin
 * **Optional widgets** - Optionally add widgets above and/or below the content
 * **Optional style sheet** - Optionally add a custom style sheet
+* **Optional ability to add code snippet** - Optionally add a code snippet to the page-- for example, Google Analytics tracking code.
 
 Bugs and pull requests are welcomed.
 

--- a/lj-maintenance-mode.php
+++ b/lj-maintenance-mode.php
@@ -156,7 +156,7 @@ class ljMaintenanceMode
 	    // add widget areas if enabled
 	    if (get_option('ljmm_add_widget_areas') ) :
 		    register_sidebar( array(
-			    'id'          => 'limm-before',
+			    'id'          => 'ljmm-before',
 			    'name'        => __( 'Maintenance mode - before content', LJMM_PLUGIN_DOMAIN ),
 			    'description' => __( '', LJMM_PLUGIN_DOMAIN ),
 			    'before_widget' => "\n".'<div id="%1$s" class="widget %2$s">',
@@ -164,7 +164,7 @@ class ljMaintenanceMode
 		    ) );
 
 		    register_sidebar( array(
-			    'id'          => 'limm-after',
+			    'id'          => 'ljmm-after',
 			    'name'        => __( 'Maintenance mode - after content', LJMM_PLUGIN_DOMAIN ),
 			    'description' => __( '', LJMM_PLUGIN_DOMAIN ),
 			    'before_widget' => "\n".'<div id="%1$s" class="widget %2$s">',
@@ -204,7 +204,7 @@ class ljMaintenanceMode
         register_setting('ljmm', 'ljmm-enabled');
         register_setting('ljmm', 'ljmm-content');
         register_setting('ljmm', 'ljmm_add_widget_areas');
-	    register_setting('ljmm', 'limm_code');
+	    register_setting('ljmm', 'ljmm_code');
         register_setting('ljmm', 'ljmm-site-title');
         register_setting('ljmm', 'ljmm-roles');
         register_setting('ljmm', 'ljmm-mode');
@@ -340,10 +340,10 @@ class ljMaintenanceMode
                     <?php endif; ?>
                     <tr valign="top">
                         <th scope="row">
-                            <label for="limm_code"><?php _e('Inject code snippet', LJMM_PLUGIN_DOMAIN); ?></label>
+                            <label for="ljmm_code"><?php _e('Inject code snippet', LJMM_PLUGIN_DOMAIN); ?></label>
                         </th>
                         <td>
-                            <textarea id="limm_code" name="limm_code" style="width:100%;height:150px"><?php echo esc_attr(get_option('limm_code')); ?></textarea>
+                            <textarea id="ljmm_code" name="ljmm_code" style="width:100%;height:150px"><?php echo esc_attr(get_option('ljmm_code')); ?></textarea>
                             <p class="description">
 				                <?php _e('This is useful to add a Javascript snippet to the page&mdash;for example, Google Analytics tracking code.', LJMM_PLUGIN_DOMAIN); ?>
                             </p>
@@ -509,8 +509,8 @@ class ljMaintenanceMode
         $content = apply_filters('ljmm_content', $content);
 
 
-        // do we have any code to inject?
-        $code = get_option('limm_code');
+            // do we have a code snippet to inject?
+        $code = get_option('ljmm_code');
 
 
         // do we have any widget areas to include?
@@ -518,11 +518,11 @@ class ljMaintenanceMode
 
 	    if (get_option('ljmm_add_widget_areas') ) :
 		    ob_start();
-            dynamic_sidebar('limm-before');
+            dynamic_sidebar('ljmm-before');
             $widget1 = ob_get_clean();
 
 		    ob_start();
-		    dynamic_sidebar('limm-after');
+		    dynamic_sidebar('ljmm-after');
 		    $widget2 = ob_get_clean();
         endif;
 
@@ -531,7 +531,7 @@ class ljMaintenanceMode
         $stylesheet = '';
 
         // we use a filter so user can change the filename of the maintenance page stylesheet
-	    $url_filename = apply_filters( 'limm_css_filename', "maintenance.css.min");
+	    $url_filename = apply_filters( 'ljmm_css_filename', "maintenance.css.min");
 
 	    // note that if validate_file returns FALSE then it means the we have a valid relative path
 	    if ( ! validate_file( $url_filename ) ) {

--- a/lj-maintenance-mode.php
+++ b/lj-maintenance-mode.php
@@ -204,6 +204,7 @@ class ljMaintenanceMode
         register_setting('ljmm', 'ljmm-enabled');
         register_setting('ljmm', 'ljmm-content');
         register_setting('ljmm', 'ljmm_add_widget_areas');
+	    register_setting('ljmm', 'limm_code');
         register_setting('ljmm', 'ljmm-site-title');
         register_setting('ljmm', 'ljmm-roles');
         register_setting('ljmm', 'ljmm-mode');
@@ -337,6 +338,17 @@ class ljMaintenanceMode
                             </td>
                         </tr>
                     <?php endif; ?>
+                    <tr valign="top">
+                        <th scope="row">
+                            <label for="limm_code"><?php _e('Inject code snippet', LJMM_PLUGIN_DOMAIN); ?></label>
+                        </th>
+                        <td>
+                            <textarea id="limm_code" name="limm_code" style="width:100%;height:150px"><?php echo esc_attr(get_option('limm_code')); ?></textarea>
+                            <p class="description">
+				                <?php _e('This is useful to add a Javascript snippet to the page&mdash;for example, Google Analytics tracking code.', LJMM_PLUGIN_DOMAIN); ?>
+                            </p>
+                        </td>
+                    </tr>
                 </table>
                 <?php submit_button(); ?>
             </form>
@@ -497,6 +509,10 @@ class ljMaintenanceMode
         $content = apply_filters('ljmm_content', $content);
 
 
+        // do we have any code to inject?
+        $code = get_option('limm_code');
+
+
         // do we have any widget areas to include?
         $widget1 = $widget2 = '';
 
@@ -526,7 +542,7 @@ class ljMaintenanceMode
 		    }
 	    }
 
-	    return $stylesheet.$widget1.$content.$widget2;
+	    return $code.$stylesheet.$widget1.$content.$widget2;
     }
 
     /**

--- a/lj-maintenance-mode.php
+++ b/lj-maintenance-mode.php
@@ -342,7 +342,7 @@ class ljMaintenanceMode
                     <?php else: ?>
                         <tr valign="top">
                             <th scope="row" colspan="2">
-                                <p class="description"><?php _e('User Role control is currently not avialable on your website. Sorry!', LJMM_PLUGIN_DOMAIN); ?></p>
+                                <p class="description"><?php _e('User Role control is currently not available on your website. Sorry!', LJMM_PLUGIN_DOMAIN); ?></p>
                             </td>
                         </tr>
                     <?php endif; ?>

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,8 @@ Help support and translate this plugin!
 * **Preview** - Preview button available.
 * **Compact** - It's developed to be as compact as possible.
 * **Role Control** - User Role control is available since 2.0
+* **Optional widgets** - Optionally add widgets above and/or below the content
+* **Optional style sheet** - Optionally add a custom style sheet
 
 > <strong>Important! Users that are using Cache plugins, please read below:</strong><br>
 > <strong>When enabling or disabling Maintenance Mode, don't forget to flush your cache!</strong>
@@ -38,6 +40,8 @@ Help support and translate this plugin!
 `ljmm_site_title` - Filter page title while in maintenance mode
 
 `ljmm_admin_bar_indicator_enabled` - Control visibility of admin bar indicator
+
+`limm_css_filename` - The filename of the CSS style sheet (as found in the theme's stylesheet directory) - just the filename, for example: 'maintenance.css.min'. (Note: you do not need to use this filter for a stylesheet; see FAQs below.)
 
 **Actions**
 `ljmm_before_mm` - Runs at the beginning of core maintenance method
@@ -52,7 +56,7 @@ Having trouble? Please read FAQ first, if you need any assistance, you can use s
 
 1. Upload `lj-maintenance-mode` to the `/wp-content/plugins/` directory
 1. Activate the plugin through the 'Plugins' menu in WordPress
-1. Navigate to Settings -> Maintenance Mode  or simply click on Admin Bar indicator for settings to enable maintenance mode.
+1. Navigate to Settings -> Maintenance Mode, or simply click on Admin Bar indicator for settings to enable maintenance mode.
 
 == Frequently Asked Questions ==
 
@@ -62,7 +66,15 @@ First, if you are using Cache plugin such as WP Super Cache or W3 Total Cache, f
 
 = Can I change background colour? =
 
-Not by default. Unless you are developer and you "inject" your own styles in to the wp_die() page.
+Not through the admin interface. You can use a custom stylesheet (see next FAQ) to do this, however.
+
+= What is the default stylesheet? =
+
+By default, the plugin will use a stylesheet named `maintenance.css.min` in the theme's stylesheet folder. You can specify a different filename by using a Filter (above).
+
+= How do I add widgets? =
+
+Click "Advanced Settings" and mark the checkbox to add widget areas. Then you will find two new widget areas in WordPress's Widgets page, for above and below the content.
 
 == Screenshots ==
 
@@ -74,11 +86,15 @@ Not by default. Unless you are developer and you "inject" your own styles in to 
 6. Insert Media available for WYSIWYG.
 
 == Changelog ==
+
+= 2.4 =
+* Added support for stylesheet and widgets (Thanks to Eric Mueller at [@switchplus](https://github.com/switchplus))
+
 = 2.3.2 =
 * Added SiteOrigin Page Builder compatibilty (Thanks to [@relgit](https://github.com/relgit))
 
 = 2.3.1 =
-* Hot Fix issue where user got locked out of admin area in maitenanice mode.
+* Hot Fix issue where user got locked out of admin area in maintenance mode.
 
 = 2.3 =
 * Small refactor, extract some of the parts to it's own method to make everything a bit cleaner

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,7 @@ Help support and translate this plugin!
 * **Role Control** - User Role control is available since 2.0
 * **Optional widgets** - Optionally add widgets above and/or below the content
 * **Optional style sheet** - Optionally add a custom style sheet
+* **Optional ability to add code snippet** - Optionally add a code snippet to the page-- for example, Google Analytics tracking code.
 
 > <strong>Important! Users that are using Cache plugins, please read below:</strong><br>
 > <strong>When enabling or disabling Maintenance Mode, don't forget to flush your cache!</strong>
@@ -88,7 +89,7 @@ Click "Advanced Settings" and mark the checkbox to add widget areas. Then you wi
 == Changelog ==
 
 = 2.4 =
-* Added support for stylesheet and widgets (Thanks to Eric Mueller at [@switchplus](https://github.com/switchplus))
+* Added support for stylesheet, widgets and code snippet injection (Thanks to Eric Mueller at [@switchplus](https://github.com/switchplus))
 
 = 2.3.2 =
 * Added SiteOrigin Page Builder compatibilty (Thanks to [@relgit](https://github.com/relgit))

--- a/readme.txt
+++ b/readme.txt
@@ -41,7 +41,7 @@ Help support and translate this plugin!
 
 `ljmm_admin_bar_indicator_enabled` - Control visibility of admin bar indicator
 
-`limm_css_filename` - The filename of the CSS style sheet (as found in the theme's stylesheet directory) - just the filename, for example: 'maintenance.css.min'. (Note: you do not need to use this filter for a stylesheet; see FAQs below.)
+`limm_css_filename` - The filename of the CSS style sheet (as found in the theme's stylesheet directory) - just the filename, for example: `maintenance.css.min`. (Note: you do not need to use this filter for a stylesheet; see FAQs below.)
 
 **Actions**
 `ljmm_before_mm` - Runs at the beginning of core maintenance method

--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,8 @@ Help support and translate this plugin!
 * **Role Control** - User Role control is available since 2.0
 * **Optional widgets** - Optionally add widgets above and/or below the content
 * **Optional style sheet** - Optionally add a custom style sheet
-* **Optional ability to add code snippet** - Optionally add a code snippet to the page-- for example, Google Analytics tracking code.
+* **Optional ability to add code snippet** - Optionally add a code snippet to the page.
+* **Support for Analytify plugin** - If you use the Analytify plugin, you can automatically insert the Google Analytics tracking code.
 
 > <strong>Important! Users that are using Cache plugins, please read below:</strong><br>
 > <strong>When enabling or disabling Maintenance Mode, don't forget to flush your cache!</strong>

--- a/uninstall.php
+++ b/uninstall.php
@@ -35,8 +35,11 @@ function ljmm_delete_plugin()
     delete_option('ljmm-site-title');
     delete_option('ljmm-roles');
     delete_option('ljmm-mode');
+	delete_option('ljmm_add_widget_areas');
+	delete_option('ljmm_analytify');
+	delete_option('ljmm_code');
 
-    // remove capabilities
+	// remove capabilities
     ljmm_remove_capabilities();
 }
 


### PR DESCRIPTION
Hi Lukas-- I added just a bit of code to support widgets above or below the content, and a custom style sheet. (We use your plugin while a site is "Coming Soon," and often want to include a little newsletter signup widget. I could also see someone potentially wanting to add a video to their page.)

I also added the ability to inject a little code snippet on the page-- for example, Google Analytics tracking code.

In the spirit of keeping the code very simple and light, I tried to make the footprint of my changes as minimal as possible.

I also took the liberty of updating the README, changelog, etc with some new info in the FAQ section, info about the new filter, and a new version number (just trying to make it easier for you!). Of course feel free to ignore, rewrite or whatever.

Would love to hear your thoughts and hope you like my improvements.

best
Eric Mueller - switchplus.ch